### PR TITLE
Fix: support ESLint ^4.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
 
 env:
   - ESLINT_VERSION=3
+  - ESLINT_VERSION=4.3
   - ESLINT_VERSION=4
 
 cache:

--- a/lib/rules/no-unused-disable.js
+++ b/lib/rules/no-unused-disable.js
@@ -28,12 +28,13 @@ module.exports = {
     },
 
     create(context) {
-        const originalReport = context.eslint.report
+        const linter = context.eslint || context._linter
+        const originalReport = linter.report
         const sourceCode = context.getSourceCode()
         const disabledArea = DisabledArea.get(sourceCode)
 
         // Override `report` method to mark disabled-area as reported.
-        context.eslint.report = function(ruleId, _severity, node, locationArg) {
+        linter.report = function(ruleId, _severity, node, locationArg) {
             const location = (typeof locationArg === "string")
                 ? node.loc.start
                 : locationArg.start || locationArg
@@ -64,14 +65,17 @@ module.exports = {
             }
 
             // Restore
-            context.eslint.report = originalReport
+            linter.report = originalReport
         }
 
         return {
             Program() {
                 // Ensure that this listener is the last in `Program:exit` listeners
                 // even if this rule was initialized before other rules.
-                context.eslint.on("Program:exit", report)
+                linter.on("Program:exit", report)
+            },
+            "Program:exit"() {
+                // Ensure that at least one Program:exit listener exists so that the report listener will be called.
             },
         }
     },

--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -313,5 +313,18 @@ var a = b
                 },
             ],
         },
+        {
+            code: "/* eslint new-parens:error*/ /*eslint-disable new-parens*/",
+            errors: [
+                {
+                    message: "'new-parens' rule is disabled but never reported.",
+                    line: 1,
+                    column: 47,
+                    endLine: 1,
+                    endColumn: 57,
+                },
+            ],
+        },
+
     ],
 })


### PR DESCRIPTION
ESLint 4.4.0 will probably be released today. It includes https://github.com/eslint/eslint/pull/8997, which refactors `RuleContext` to rename some internal properties. Since this plugin relies on `context.eslint` as a private API, it won't work because that property was renamed to `context._linter` to clarify that it usually shouldn't be used.

Additionally, since ESLint 3.18.0, node type listeners need to be added before traversal starts (because they are indexed beforehand in [`node-event-generator`](https://github.com/eslint/eslint/blob/37158c58eef18ff6d61a9e6ffdf62fe7dc5a03af/lib/util/node-event-generator.js) in order to support selectors). Since `no-unused-disable` adds a listener at runtime, this could cause a false negative if no other active rules added a `Program:exit` listener. For example, no error is reported for the following code:

```js
/* eslint-disable new-parens */
a;
```

Unfortunately, this wasn't caught with `RuleTester` because `RuleTester` also adds a `Program:exit` listener. (In general, I think `RuleTester` doesn't support adding listeners at runtime.)