### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/disable-enable-pair.js
+++ b/lib/rules/disable-enable-pair.js
@@ -22,6 +22,7 @@ module.exports = {
             description: "requires a `eslint-enable` comment for every `eslint-disable` comment",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/disable-enable-pair.md",
         },
         fixable: false,
         schema: [{

--- a/lib/rules/no-aggregating-enable.js
+++ b/lib/rules/no-aggregating-enable.js
@@ -51,6 +51,7 @@ module.exports = {
             description: "disallows `eslint-enable` comments for multiple `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-aggregating-enable.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-duplicate-disable.js
+++ b/lib/rules/no-duplicate-disable.js
@@ -22,6 +22,7 @@ module.exports = {
             description: "disallows duplicate `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-duplicate-disable.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-restricted-disable.js
+++ b/lib/rules/no-restricted-disable.js
@@ -58,6 +58,7 @@ module.exports = {
             description: "disallows `eslint-disable` comments about specific rules",
             category: "Stylistic Issues",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-restricted-disable.md",
         },
         fixable: false,
         schema: {

--- a/lib/rules/no-unlimited-disable.js
+++ b/lib/rules/no-unlimited-disable.js
@@ -30,6 +30,7 @@ module.exports = {
             description: "disallows `eslint-disable` comments without rule names",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unlimited-disable.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-unused-disable.js
+++ b/lib/rules/no-unused-disable.js
@@ -22,6 +22,7 @@ module.exports = {
             description: "disallows unused `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unused-disable.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-unused-enable.js
+++ b/lib/rules/no-unused-enable.js
@@ -22,6 +22,7 @@ module.exports = {
             description: "disallows unused `eslint-enable` comments",
             category: "Best Practices",
             recommended: true,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unused-enable.md",
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-use.js
+++ b/lib/rules/no-use.js
@@ -30,6 +30,7 @@ module.exports = {
             description: "disallows ESLint directive-comments",
             category: "Stylistic Issues",
             recommended: false,
+            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-use.md",
         },
         fixable: false,
         schema: [{


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.