### PR TITLE
Docs: Use link to tagged version for rule docs

### DIFF
--- a/lib/rules/disable-enable-pair.js
+++ b/lib/rules/disable-enable-pair.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "requires a `eslint-enable` comment for every `eslint-disable` comment",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/disable-enable-pair.md",
+            url: utils.getDocsUrl("disable-enable-pair"),
         },
         fixable: false,
         schema: [{

--- a/lib/rules/no-aggregating-enable.js
+++ b/lib/rules/no-aggregating-enable.js
@@ -51,7 +51,7 @@ module.exports = {
             description: "disallows `eslint-enable` comments for multiple `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-aggregating-enable.md",
+            url: utils.getDocsUrl("no-aggregating-enable"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-duplicate-disable.js
+++ b/lib/rules/no-duplicate-disable.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "disallows duplicate `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-duplicate-disable.md",
+            url: utils.getDocsUrl("no-duplicate-disable"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-restricted-disable.js
+++ b/lib/rules/no-restricted-disable.js
@@ -58,7 +58,7 @@ module.exports = {
             description: "disallows `eslint-disable` comments about specific rules",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-restricted-disable.md",
+            url: utils.getDocsUrl("no-restricted-disable"),
         },
         fixable: false,
         schema: {

--- a/lib/rules/no-unlimited-disable.js
+++ b/lib/rules/no-unlimited-disable.js
@@ -30,7 +30,7 @@ module.exports = {
             description: "disallows `eslint-disable` comments without rule names",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unlimited-disable.md",
+            url: utils.getDocsUrl("no-unlimited-disable"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-unused-disable.js
+++ b/lib/rules/no-unused-disable.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "disallows unused `eslint-disable` comments",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unused-disable.md",
+            url: utils.getDocsUrl("no-unused-disable"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-unused-enable.js
+++ b/lib/rules/no-unused-enable.js
@@ -22,7 +22,7 @@ module.exports = {
             description: "disallows unused `eslint-enable` comments",
             category: "Best Practices",
             recommended: true,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-unused-enable.md",
+            url: utils.getDocsUrl("no-unused-enable"),
         },
         fixable: false,
         schema: [],

--- a/lib/rules/no-use.js
+++ b/lib/rules/no-use.js
@@ -30,7 +30,7 @@ module.exports = {
             description: "disallows ESLint directive-comments",
             category: "Stylistic Issues",
             recommended: false,
-            url: "https://github.com/mysticatea/eslint-plugin-eslint-comments/tree/master/docs/rules/no-use.md",
+            url: utils.getDocsUrl("no-use"),
         },
         fixable: false,
         schema: [{

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,12 +10,14 @@
 //------------------------------------------------------------------------------
 
 const escapeStringRegexp = require("escape-string-regexp")
+const pkg = require("../package")
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 const LINE_PATTERN = /[^\r\n\u2028\u2029]*(?:\r\n|[\r\n\u2028\u2029]|$)/g
+const REPO_URL = "https://github.com/mysticatea/eslint-plugin-eslint-comments"
 
 //------------------------------------------------------------------------------
 // Exports
@@ -103,5 +105,17 @@ module.exports = {
      */
     lte(a, b) {
         return a.line < b.line || (a.line === b.line && a.column <= b.column)
+    },
+
+    /**
+     * Generates the URL to documentation for the given rule name. It uses the
+     * package version to build the link to a tagged version of the
+     * documentation file.
+     *
+     * @param {string} ruleName - Name of the eslint rule
+     * @returns {string} URL to the documentation for the given rule
+     */
+    getDocsUrl(ruleName) {
+        return `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`
     },
 }


### PR DESCRIPTION
This adds a utility function and uses the version present in package.json for generating the URL to tagged version of the rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.