### PR TITLE
fix links in rules docs

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -7,17 +7,17 @@
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [eslint-comments/<wbr>disable-enable-pair](./disable-enable-pair.html) | require a `eslint-enable` comment for every `eslint-disable` comment | 🌟 |
-| [eslint-comments/<wbr>no-aggregating-enable](./no-aggregating-enable.html) | disallow a `eslint-enable` comment for multiple `eslint-disable` comments | 🌟 |
-| [eslint-comments/<wbr>no-duplicate-disable](./no-duplicate-disable.html) | disallow duplicate `eslint-disable` comments | 🌟 |
-| [eslint-comments/<wbr>no-unlimited-disable](./no-unlimited-disable.html) | disallow `eslint-disable` comments without rule names | 🌟 |
-| [eslint-comments/<wbr>no-unused-disable](./no-unused-disable.html) | disallow unused `eslint-disable` comments |  |
-| [eslint-comments/<wbr>no-unused-enable](./no-unused-enable.html) | disallow unused `eslint-enable` comments | 🌟 |
+| [eslint-comments/<wbr>disable-enable-pair](./disable-enable-pair.md) | require a `eslint-enable` comment for every `eslint-disable` comment | 🌟 |
+| [eslint-comments/<wbr>no-aggregating-enable](./no-aggregating-enable.md) | disallow a `eslint-enable` comment for multiple `eslint-disable` comments | 🌟 |
+| [eslint-comments/<wbr>no-duplicate-disable](./no-duplicate-disable.md) | disallow duplicate `eslint-disable` comments | 🌟 |
+| [eslint-comments/<wbr>no-unlimited-disable](./no-unlimited-disable.md) | disallow `eslint-disable` comments without rule names | 🌟 |
+| [eslint-comments/<wbr>no-unused-disable](./no-unused-disable.md) | disallow unused `eslint-disable` comments |  |
+| [eslint-comments/<wbr>no-unused-enable](./no-unused-enable.md) | disallow unused `eslint-enable` comments | 🌟 |
 
 ## Stylistic Issues
 
 | Rule ID | Description |    |
 |:--------|:------------|:---|
-| [eslint-comments/<wbr>no-restricted-disable](./no-restricted-disable.html) | disallow `eslint-disable` comments about specific rules |  |
-| [eslint-comments/<wbr>no-use](./no-use.html) | disallow ESLint directive-comments |  |
+| [eslint-comments/<wbr>no-restricted-disable](./no-restricted-disable.md) | disallow `eslint-disable` comments about specific rules |  |
+| [eslint-comments/<wbr>no-use](./no-use.md) | disallow ESLint directive-comments |  |
 


### PR DESCRIPTION
When looking through the README.md, I noticed all of the links pointed to `.html` instead of `.md`, this fixes that so that the links are pointing to the right place.