### PR TITLE
🐛 fix for ESLint 6 (fixes #24)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,14 @@ jobs:
 
   - template: .azure-pipelines/test-job.yml
     parameters:
+      name: test_on_linux_node12_eslint6rc
+      displayName: Test on Node 12, ESLint 6 RC, Linux
+      vmImage: Ubuntu-16.04
+      nodeVersion: 12.x
+      eslintVersion: ^6.0.0-rc.0
+
+  - template: .azure-pipelines/test-job.yml
+    parameters:
       name: test_on_windows_node12_eslint5
       displayName: Test on Node 12, ESLint 5, Windows
       vmImage: Windows-2019

--- a/lib/utils/patch.js
+++ b/lib/utils/patch.js
@@ -138,10 +138,9 @@ function convert(messages, sourceCode, ruleId, severity, keepAsIs) {
 
 module.exports = (ruleId = "eslint-comments/no-unused-disable") => {
     for (const Linter of getLinters()) {
-        const verify0 = Linter.prototype.verify
-
-        Object.defineProperty(Linter.prototype, "verify", {
-            value: function verify(
+        const verify0 = Linter.prototype._verifyWithoutProcessors
+        Object.defineProperty(Linter.prototype, "_verifyWithoutProcessors", {
+            value: function _verifyWithoutProcessors(
                 textOrSourceCode,
                 config,
                 filenameOrOptions

--- a/tests/lib/rules/disable-enable-pair.js
+++ b/tests/lib/rules/disable-enable-pair.js
@@ -71,7 +71,7 @@ console.log('This code does not even have any special comments')
         },
         {
             code: `
-/*eslint-disable no-unused-var, no-undef */
+/*eslint-disable no-unused-vars, no-undef */
 var foo = 1
 `,
             options: [{ allowWholeFile: true }],

--- a/tests/lib/rules/no-aggregating-enable.js
+++ b/tests/lib/rules/no-aggregating-enable.js
@@ -11,32 +11,32 @@ const tester = new RuleTester()
 tester.run("no-aggregating-enable", rule, {
     valid: [
         `
-            /*eslint-disable a*/
-            /*eslint-enable a*/
+            /*eslint-disable no-redeclare*/
+            /*eslint-enable no-redeclare*/
         `,
         `
-            /*eslint-disable a*/
-            /*eslint-enable b*/
+            /*eslint-disable no-redeclare*/
+            /*eslint-enable no-shadow*/
         `,
         `
-            /*eslint-disable a, b*/
+            /*eslint-disable no-redeclare, no-shadow*/
             /*eslint-enable*/
         `,
         `
-            /*eslint-disable a, b*/
-            /*eslint-enable a, b*/
+            /*eslint-disable no-redeclare, no-shadow*/
+            /*eslint-enable no-redeclare, no-shadow*/
         `,
         `
-            /*eslint-disable a, b*/
-            /*eslint-enable a*/
-            /*eslint-enable b*/
+            /*eslint-disable no-redeclare, no-shadow*/
+            /*eslint-enable no-redeclare*/
+            /*eslint-enable no-shadow*/
         `,
     ],
     invalid: [
         {
             code: `
-                /*eslint-disable a*/
-                /*eslint-disable b*/
+                /*eslint-disable no-redeclare*/
+                /*eslint-disable no-shadow*/
                 /*eslint-enable*/
             `,
             errors: [
@@ -45,9 +45,9 @@ tester.run("no-aggregating-enable", rule, {
         },
         {
             code: `
-                /*eslint-disable a*/
-                /*eslint-disable b*/
-                /*eslint-disable c*/
+                /*eslint-disable no-redeclare*/
+                /*eslint-disable no-shadow*/
+                /*eslint-disable no-undef*/
                 /*eslint-enable*/
             `,
             errors: [
@@ -56,9 +56,9 @@ tester.run("no-aggregating-enable", rule, {
         },
         {
             code: `
-                /*eslint-disable a*/
-                /*eslint-disable b*/
-                /*eslint-enable a, b*/
+                /*eslint-disable no-redeclare*/
+                /*eslint-disable no-shadow*/
+                /*eslint-enable no-redeclare, no-shadow*/
             `,
             errors: [
                 "This `eslint-enable` comment affects 2 `eslint-disable` comments. An `eslint-enable` comment should be for an `eslint-disable` comment.",

--- a/tests/lib/rules/no-restricted-disable.js
+++ b/tests/lib/rules/no-restricted-disable.js
@@ -4,9 +4,13 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-restricted-disable")
+const coreRules = new Linter().getRules()
 const tester = new RuleTester()
+
+tester.defineRule("foo/no-undef", coreRules.get("no-undef"))
+tester.defineRule("foo/no-redeclare", coreRules.get("no-redeclare"))
 
 tester.run("no-restricted-disable", rule, {
     valid: [
@@ -14,79 +18,79 @@ tester.run("no-restricted-disable", rule, {
         "//eslint-disable-line",
         "//eslint-disable-next-line",
         {
-            code: "/*eslint-disable b*/",
-            options: ["a"],
+            code: "/*eslint-disable eqeqeq*/",
+            options: ["no-unused-vars"],
         },
         {
-            code: "/*eslint-enable a*/",
-            options: ["a"],
+            code: "/*eslint-enable eqeqeq*/",
+            options: ["eqeqeq"],
         },
         {
-            code: "/*eslint-disable a*/",
-            options: ["*", "!a"],
+            code: "/*eslint-disable eqeqeq*/",
+            options: ["*", "!eqeqeq"],
         },
     ],
     invalid: [
         {
-            code: "/*eslint-disable a*/",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "/*eslint-disable eqeqeq*/",
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "/*eslint-disable*/",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
-            code: "//eslint-disable-line a",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "//eslint-disable-line eqeqeq",
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "//eslint-disable-line",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
-            code: "//eslint-disable-next-line a",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "//eslint-disable-next-line eqeqeq",
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "//eslint-disable-next-line",
-            options: ["a"],
-            errors: ["Disabling 'a' is not allowed."],
+            options: ["eqeqeq"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
 
         {
-            code: "/*eslint-disable a, b, c*/",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "/*eslint-disable eqeqeq, no-undef, no-redeclare*/",
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "/*eslint-disable*/",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling '*,!b,!c' is not allowed."],
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling '*,!no-undef,!no-redeclare' is not allowed."],
         },
         {
-            code: "//eslint-disable-line a, b, c",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "//eslint-disable-line eqeqeq, no-undef, no-redeclare",
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "//eslint-disable-line",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling '*,!b,!c' is not allowed."],
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling '*,!no-undef,!no-redeclare' is not allowed."],
         },
         {
-            code: "//eslint-disable-next-line a, b, c",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling 'a' is not allowed."],
+            code: "//eslint-disable-next-line eqeqeq, no-undef, no-redeclare",
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling 'eqeqeq' is not allowed."],
         },
         {
             code: "//eslint-disable-next-line",
-            options: ["*", "!b", "!c"],
-            errors: ["Disabling '*,!b,!c' is not allowed."],
+            options: ["*", "!no-undef", "!no-redeclare"],
+            errors: ["Disabling '*,!no-undef,!no-redeclare' is not allowed."],
         },
 
         {
@@ -100,11 +104,12 @@ tester.run("no-restricted-disable", rule, {
             ],
         },
         {
-            code: "/*eslint-disable a, b, react/a, react/b*/",
-            options: ["react/*"],
+            code:
+                "/*eslint-disable no-undef, no-redeclare, foo/no-undef, foo/no-redeclare*/",
+            options: ["foo/*"],
             errors: [
-                "Disabling 'react/a' is not allowed.",
-                "Disabling 'react/b' is not allowed.",
+                "Disabling 'foo/no-undef' is not allowed.",
+                "Disabling 'foo/no-redeclare' is not allowed.",
             ],
         },
     ],

--- a/tests/lib/rules/no-unlimited-disable.js
+++ b/tests/lib/rules/no-unlimited-disable.js
@@ -11,10 +11,10 @@ const tester = new RuleTester()
 tester.run("no-unlimited-disable", rule, {
     valid: [
         "/*eslint-enable*/",
-        "/*eslint-disable foo*/",
-        "//eslint-disable-line foo",
-        "//eslint-disable-next-line foo",
-        "var foo;\n//eslint-disable-line foo",
+        "/*eslint-disable eqeqeq*/",
+        "//eslint-disable-line eqeqeq",
+        "//eslint-disable-next-line eqeqeq",
+        "var foo;\n//eslint-disable-line eqeqeq",
     ],
     invalid: [
         {

--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -409,17 +409,18 @@ var a = b//eslint-disable-line no-undef`,
 /*eslint-disable
     no-undef,
     no-unused-vars,
-    xxxx
+    eqeqeq
 */
 var a = b
 /*eslint-enable*/`,
                 errors: [
                     {
-                        message: "'xxxx' rule is disabled but never reported.",
+                        message:
+                            "'eqeqeq' rule is disabled but never reported.",
                         line: 5,
                         column: 5,
                         endLine: 5,
-                        endColumn: 9,
+                        endColumn: 11,
                     },
                 ],
             },


### PR DESCRIPTION
Fixes #24.

- `Linter#verify` now receives `ConfigArray` object as the `config` parameter. It can be different settings per code blocks if people used multiple processors, so `no-unused-disable` rule cannot work with the current approach. Instead, `no-unused-disable` rule patches `_verifyWithoutProcessors` method for now.
- ESLint now throws on unknown rules in `/*eslint-disable*/` comments.