### PR TITLE
Test: no-unused-disable for capitalized-comments

### DIFF
--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -133,6 +133,12 @@ function baz() {
     var foo = 3  //eslint-disable-line no-shadow
 }
 `,
+            `
+            /* eslint capitalized-comments: ["error"] */\n// eslint-disable-next-line capitalized-comments\n// lowercase comment\n
+            `,
+            `
+            /* eslint capitalized-comments: ["error"] */\r\n// eslint-disable-next-line capitalized-comments\r\n/* lowercase comment */\r\n
+            `,
         ]) {
             it(code, () =>
                 runESLint(code).then(messages => {


### PR DESCRIPTION
Adding a test to verify if this rule is working for
capitalized-comments. I could not replicate the issue locally on linux
where earlier in the week I could on windows.

Refs #34 and eslint/eslint#12548