### PR TITLE
Add option "excludePaths" to "no-unlimited-disable" rule

### DIFF
--- a/lib/rules/no-unlimited-disable.js
+++ b/lib/rules/no-unlimited-disable.js
@@ -4,6 +4,8 @@
  */
 "use strict"
 
+const ignore = require("ignore")
+
 const utils = require("../internal/utils")
 
 const PATTERNS = {
@@ -23,11 +25,34 @@ module.exports = {
                 "https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unlimited-disable.html",
         },
         fixable: null,
-        schema: [],
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    excludePaths: {
+                        type: "array",
+                        items: {
+                            type: "string",
+                        },
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
     },
 
     create(context) {
         const sourceCode = context.getSourceCode()
+        const excluded = context.options[0] && context.options[0].excludePaths
+
+        if (Array.isArray(excluded)) {
+            const filename = context.getFilename()
+            const ig = ignore().add(excluded)
+
+            if (ig.ignores(filename)) {
+                return {}
+            }
+        }
 
         return {
             Program() {

--- a/tests/lib/rules/no-unlimited-disable.js
+++ b/tests/lib/rules/no-unlimited-disable.js
@@ -15,6 +15,11 @@ tester.run("no-unlimited-disable", rule, {
         "//eslint-disable-line eqeqeq",
         "//eslint-disable-next-line eqeqeq",
         "var foo;\n//eslint-disable-line eqeqeq",
+        {
+            code: "/*eslint-disable */",
+            options: [{ excludePaths: ["__generated__/*"] }],
+            filename: "__generated__/File.js",
+        },
     ],
     invalid: [
         {
@@ -58,6 +63,14 @@ tester.run("no-unlimited-disable", rule, {
             errors: [
                 "Unexpected unlimited 'eslint-disable-line' comment. Specify some rule names to disable.",
             ],
+        },
+        {
+            code: "/*eslint-disable */",
+            options: [{ excludePaths: ["__generated__/*"] }],
+            errors: [
+                "Unexpected unlimited 'eslint-disable' comment. Specify some rule names to disable.",
+            ],
+            filename: "path/File.js",
         },
     ],
 })


### PR DESCRIPTION
Hello! 👋 

Thanks for this awesome plugin. We use most of the rules except `no-unlimited-disable` - we had to disable it as our application contains autogenerated javascript files - this is relevant mostly to all apps which use [relay](https://relay.dev/) client for GraphQL server - see example here of such file: https://github.com/adeira/relay-example/blob/master/src/LocalForm/__generated__/LocalFormQuery.graphql.js#L6

For that reason, I got an idea we could still turn on `no-unlimited-disable` while excluding these autogenerated files, what do you think?