### PR TITLE
Add `eslint-comments/require-description` rule

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -20,4 +20,5 @@
 |:--------|:------------|:---|
 | [eslint-comments/<wbr>no-restricted-disable](./no-restricted-disable.md) | disallow `eslint-disable` comments about specific rules |  |
 | [eslint-comments/<wbr>no-use](./no-use.md) | disallow ESLint directive-comments |  |
+| [eslint-comments/<wbr>require-description](./require-description.md) | require include descriptions in ESLint directive-comments |  |
 

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -1,0 +1,57 @@
+# eslint-comments/require-description
+
+> require include descriptions in ESLint directive-comments
+
+This rule warns directive comments without description.
+
+:::warning
+This rule can only be used with ESLint v7.x or later.
+:::
+
+## Rule Details
+
+Examples of :-1: **incorrect** code for this rule:
+
+<eslint-playground type="bad" code="/*eslint eslint-comments/require-description: error */
+
+/* eslint no-undef: off */
+/* eslint-env browser */
+/* eslint-disable eqeqeq */
+/* eslint-enable eqeqeq */
+// eslint-disable-line
+// eslint-disable-next-line
+/* exported foo */
+/* global $ */
+/* globals a, b, c */
+" />
+
+Examples of :+1: **correct** code for this rule:
+
+<eslint-playground type="good" code="/*eslint eslint-comments/require-description: error -- If you use directive comments, you should explain why you use them. */
+
+/* eslint no-undef: off -- Here's a description about why this directive-comment is necessary. */
+/* eslint-env browser -- This script works in browser. */
+// eslint-disable-next-line -- Temporarily avoids the lint error problem. See issue XXX.
+/* global $ -- This script using jQuery. */
+" />
+
+## Options
+
+You can specify ignored directive-comments.
+
+```json
+{
+    "eslint-comments/require-description": ["error", {"ignore": []}]
+}
+```
+
+- `ignore` option is an array to ignore specified directive-comments. The value of the array is some of the following strings:
+    - `"eslint"`
+    - `"eslint-disable"`
+    - `"eslint-disable-line"`
+    - `"eslint-disable-next-line"`
+    - `"eslint-enable"`
+    - `"eslint-env"`
+    - `"exported"`
+    - `"global"`
+    - `"globals"`

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -55,3 +55,9 @@ You can specify ignored directive-comments.
     - `"exported"`
     - `"global"`
     - `"globals"`
+
+## Further Reading
+
+- [ESLint RFCs - Description in directive comments]
+
+[ESLint RFCs - Description in directive comments]: https://github.com/eslint/rfcs/blob/master/designs/2019-description-in-directive-comments/README.md

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -10,4 +10,5 @@ module.exports = {
     "no-unused-disable": require("./rules/no-unused-disable"),
     "no-unused-enable": require("./rules/no-unused-enable"),
     "no-use": require("./rules/no-use"),
+    "require-description": require("./rules/require-description"),
 }

--- a/lib/rules/require-description.js
+++ b/lib/rules/require-description.js
@@ -1,0 +1,78 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const utils = require("../internal/utils")
+
+module.exports = {
+    meta: {
+        type: "suggestion",
+        docs: {
+            description:
+                "require include descriptions in ESLint directive-comments",
+            category: "Stylistic Issues",
+            recommended: false,
+            url:
+                "https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/require-description.html",
+        },
+        fixable: null,
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    ignore: {
+                        type: "array",
+                        items: {
+                            enum: [
+                                "eslint",
+                                "eslint-disable",
+                                "eslint-disable-line",
+                                "eslint-disable-next-line",
+                                "eslint-enable",
+                                "eslint-env",
+                                "exported",
+                                "global",
+                                "globals",
+                            ],
+                        },
+                        additionalItems: false,
+                        uniqueItems: true,
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode()
+        const ignores = new Set(
+            (context.options[0] && context.options[0].ignore) || []
+        )
+
+        return {
+            Program() {
+                for (const comment of sourceCode.getAllComments()) {
+                    const directiveComment = utils.parseDirectiveComment(
+                        comment
+                    )
+                    if (directiveComment == null) {
+                        continue
+                    }
+                    if (ignores.has(directiveComment.kind)) {
+                        continue
+                    }
+                    if (!directiveComment.description) {
+                        context.report({
+                            loc: utils.toForceLocation(comment.loc),
+                            message:
+                                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+                        })
+                    }
+                }
+            },
+        }
+    },
+}

--- a/lib/rules/require-description.js
+++ b/lib/rules/require-description.js
@@ -8,7 +8,6 @@ const utils = require("../internal/utils")
 
 module.exports = {
     meta: {
-        type: "suggestion",
         docs: {
             description:
                 "require include descriptions in ESLint directive-comments",
@@ -44,6 +43,7 @@ module.exports = {
                 additionalProperties: false,
             },
         ],
+        type: "suggestion",
     },
 
     create(context) {

--- a/tests/lib/rules/require-description.js
+++ b/tests/lib/rules/require-description.js
@@ -1,0 +1,214 @@
+/**
+ * @author Yosuke Ota <https://github.com/ota-meshi>
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+const semver = require("semver")
+const eslintVersion = require("eslint/package").version
+const RuleTester = require("eslint").RuleTester
+const rule = require("../../../lib/rules/require-description")
+const tester = new RuleTester()
+
+if (!semver.satisfies(eslintVersion, ">=7.0.0")) {
+    // This rule can only be used with ESLint v7.x or later.
+    return
+}
+
+tester.run("require-description", rule, {
+    valid: [
+        '/* eslint eqeqeq: "off", curly: "error" -- Here\'s a description about why this configuration is necessary. */',
+        "/* eslint-disable -- description */",
+        "/* eslint-enable -- description */",
+        "/* exported -- description */",
+        "/* global -- description */",
+        "/* globals -- description */",
+        "/* eslint-env -- description */",
+        "/* just eslint in a normal comment */",
+        "// eslint-disable-line -- description",
+        "// eslint-disable-next-line -- description",
+        "/* eslint-disable-line -- description */",
+        "/* eslint-disable-next-line -- description */",
+        "// eslint-disable-line eqeqeq -- description",
+        "// eslint-disable-next-line eqeqeq -- description",
+        {
+            code: "/* eslint */",
+            options: [{ ignore: ["eslint"] }],
+        },
+        {
+            code: "/* eslint-env */",
+            options: [{ ignore: ["eslint-env"] }],
+        },
+        {
+            code: "/* eslint-enable */",
+            options: [{ ignore: ["eslint-enable"] }],
+        },
+        {
+            code: "/* eslint-disable */",
+            options: [{ ignore: ["eslint-disable"] }],
+        },
+        {
+            code: "// eslint-disable-line",
+            options: [{ ignore: ["eslint-disable-line"] }],
+        },
+        {
+            code: "// eslint-disable-next-line",
+            options: [{ ignore: ["eslint-disable-next-line"] }],
+        },
+        {
+            code: "/* eslint-disable-line */",
+            options: [{ ignore: ["eslint-disable-line"] }],
+        },
+        {
+            code: "/* eslint-disable-next-line */",
+            options: [{ ignore: ["eslint-disable-next-line"] }],
+        },
+        {
+            code: "/* exported */",
+            options: [{ ignore: ["exported"] }],
+        },
+        {
+            code: "/* global */",
+            options: [{ ignore: ["global"] }],
+        },
+        {
+            code: "/* globals */",
+            options: [{ ignore: ["globals"] }],
+        },
+    ],
+    invalid: [
+        {
+            code: "/* eslint */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: '/* eslint eqeqeq: "off", curly: "error" */',
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-env */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-env node */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-enable */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-enable eqeqeq */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable eqeqeq */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "// eslint-disable-line",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "// eslint-disable-line eqeqeq",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "// eslint-disable-next-line",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "// eslint-disable-next-line eqeqeq",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable-line */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable-line eqeqeq */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable-next-line */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* eslint-disable-next-line eqeqeq */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* exported */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* global */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* global _ */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* globals */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        {
+            code: "/* globals _ */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+        // empty description
+        {
+            code: "/* eslint-disable-next-line eqeqeq -- */",
+            errors: [
+                "Unexpected undescribed directive comment. Include descriptions to explain why the comment is necessary.",
+            ],
+        },
+    ],
+})


### PR DESCRIPTION
This PR adds `eslint-comments/require-description` rule.
This rule warns directive comments without description.
This rule can only be used with ESLint v7.x or later.

---

close #40
close #29