### PR TITLE
require-description: previous line comment check

### DIFF
--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -33,6 +33,9 @@ Examples of :+1: **correct** code for this rule:
 /* eslint-env browser -- This script works in browser. */
 // eslint-disable-next-line -- Temporarily avoids the lint error problem. See issue XXX.
 /* global $ -- This script using jQuery. */
+
+// Temporarily avoids the lint error problem. See issue XXX.
+// eslint-disable-next-line
 " />
 
 ## Options

--- a/lib/internal/utils.js
+++ b/lib/internal/utils.js
@@ -135,6 +135,18 @@ module.exports = {
             description,
         }
     },
+
+    /**
+     * Creates an object hashmap
+     * @param {Object[]} values 
+     * @param {Function} getKey 
+     */
+    keyBy(values, getKey){
+        return values.reduce((accumulator, value) => {
+          accumulator[getKey(value)] = value;
+          return accumulator;
+        }, {});
+      }
 }
 
 /**

--- a/lib/internal/utils.js
+++ b/lib/internal/utils.js
@@ -138,15 +138,15 @@ module.exports = {
 
     /**
      * Creates an object hashmap
-     * @param {Object[]} values 
-     * @param {Function} getKey 
+     * @param {Object[]} values
+     * @param {Function} getKey
      */
-    keyBy(values, getKey){
+    keyBy(values, getKey) {
         return values.reduce((accumulator, value) => {
-          accumulator[getKey(value)] = value;
-          return accumulator;
-        }, {});
-      }
+            accumulator[getKey(value)] = value
+            return accumulator
+        }, {})
+    },
 }
 
 /**

--- a/lib/rules/require-description.js
+++ b/lib/rules/require-description.js
@@ -52,9 +52,16 @@ module.exports = {
             (context.options[0] && context.options[0].ignore) || []
         )
 
+        const comments = sourceCode.getAllComments()
+        const commentMapByLine = utils.keyBy(comments, comment => comment.loc.end.line)
+
+        function previousLineHasComment(comment){
+            return !!commentMapByLine[comment.loc.start.line -1]
+        }
+
         return {
             Program() {
-                for (const comment of sourceCode.getAllComments()) {
+                for (const comment of comments) {
                     const directiveComment = utils.parseDirectiveComment(
                         comment
                     )
@@ -64,7 +71,7 @@ module.exports = {
                     if (ignores.has(directiveComment.kind)) {
                         continue
                     }
-                    if (!directiveComment.description) {
+                    if (!directiveComment.description && !previousLineHasComment(comment)) {
                         context.report({
                             loc: utils.toForceLocation(comment.loc),
                             message:

--- a/lib/rules/require-description.js
+++ b/lib/rules/require-description.js
@@ -53,10 +53,13 @@ module.exports = {
         )
 
         const comments = sourceCode.getAllComments()
-        const commentMapByLine = utils.keyBy(comments, comment => comment.loc.end.line)
+        const commentMapByLine = utils.keyBy(
+            comments,
+            comment => comment.loc.end.line
+        )
 
-        function previousLineHasComment(comment){
-            return !!commentMapByLine[comment.loc.start.line -1]
+        function previousLineHasComment(comment) {
+            return Boolean(commentMapByLine[comment.loc.start.line - 1])
         }
 
         return {
@@ -71,7 +74,10 @@ module.exports = {
                     if (ignores.has(directiveComment.kind)) {
                         continue
                     }
-                    if (!directiveComment.description && !previousLineHasComment(comment)) {
+                    if (
+                        !directiveComment.description &&
+                        !previousLineHasComment(comment)
+                    ) {
                         context.report({
                             loc: utils.toForceLocation(comment.loc),
                             message:

--- a/tests/lib/rules/require-description.js
+++ b/tests/lib/rules/require-description.js
@@ -31,6 +31,8 @@ tester.run("require-description", rule, {
         "/* eslint-disable-next-line -- description */",
         "// eslint-disable-line eqeqeq -- description",
         "// eslint-disable-next-line eqeqeq -- description",
+        `// some comment above
+// eslint-disable-next-line eqeqeq`,
         {
             code: "/* eslint */",
             options: [{ ignore: ["eslint"] }],


### PR DESCRIPTION
I figured I'd give [multi line comments for `require-description` ](https://github.com/mysticatea/eslint-plugin-eslint-comments/issues/55)a try. It seems to work?