### PR TITLE
feat: support ESLint 8.x

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,7 +5,7 @@ extends:
 overrides:
   - files: "docs/.vuepress/components/*.vue"
     parserOptions:
-      parser: babel-eslint
+      parser: "@babel/eslint-parser"
 
   - files: "lib/rules/*.js"
     rules:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,73 +5,78 @@ on:
   pull_request:
     branches: [master]
   schedule:
-  - cron: 0 0 * * 0
+    - cron: 0 0 * * 0
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install Node.js
-      uses: actions/setup-node@v1
-      with: { node-version: 14.x }
-    - name: Install Packages
-      run: npm install
-    - name: Lint
-      run: npm run -s lint
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - name: Install Packages
+        run: npm install
+      - name: Lint
+        run: npm run -s lint
 
   test:
     name: Test
     strategy:
       matrix:
-        eslint: [7.x]
-        node: [14.x]
+        eslint: ["^8.0.0-0"]
+        node: [16]
         os: [ubuntu-latest]
         include:
-        # On other platforms
-        - eslint: 7.x
-          node: 14.x
-          os: windows-latest
-        - eslint: 7.x
-          node: 14.x
-          os: macos-latest
-        # On old Node.js versions
-        - eslint: 7.x
-          node: 12.x
-          os: ubuntu-latest
-        - eslint: 7.x
-          node: 10.x
-          os: ubuntu-latest
-        - eslint: 6.x
-          node: 8.x
-          os: ubuntu-latest
-        - eslint: 5.x
-          node: 6.x
-          os: ubuntu-latest
-        # On the minimum supported ESLint/Node.js version
-        - eslint: "4.19.1"
-          node: "6.5.0"
-          os: ubuntu-latest
+          # On other platforms
+          - eslint: "^8.0.0-0"
+            node: 16
+            os: windows-latest
+          - eslint: "^8.0.0-0"
+            node: 16
+            os: macos-latest
+          # On old Node.js versions
+          - eslint: "^8.0.0-0"
+            node: 14
+            os: ubuntu-latest
+          - eslint: "^8.0.0-0"
+            node: 12
+            os: ubuntu-latest
+          - eslint: 7
+            node: 10
+            os: ubuntu-latest
+          - eslint: 6
+            node: 8
+            os: ubuntu-latest
+          - eslint: 5
+            node: 6
+            os: ubuntu-latest
+          # On the minimum supported ESLint/Node.js version
+          - eslint: 4.19.1
+            node: 6.5.0
+            os: ubuntu-latest
 
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Install Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v1
-      with: { node-version: "${{ matrix.node }}" }
-    - name: Install npm 6.x
-      run: npm install --global npm@6.x
-      if: ${{ matrix.node == '6.x' || matrix.node == '6.5.0' }}
-    - name: Install Packages
-      run: npm install
-    - name: Install ESLint ${{ matrix.eslint }}
-      run: npm install --no-save eslint@${{ matrix.eslint }}
-    - name: Test
-      run: npm run -s test:ci
-    - name: Send Coverage
-      run: npm run -s codecov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install npm 6
+        run: npm install --global npm@6.x
+        if: ${{ matrix.node == '6' || matrix.node == '6.5.0' }}
+      - name: Install Packages
+        run: npm install
+      - name: Install ESLint ${{ matrix.eslint }}
+        run: npm install --no-save eslint@${{ matrix.eslint }}
+      - name: Test
+        run: npm run -s test:ci
+      - name: Send Coverage
+        run: npm run -s codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
     "ignore": "^5.0.5"
   },
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/eslint-parser": "^7.15.0",
     "@mysticatea/eslint-plugin": "^13.0.0",
     "@types/node": "^14.0.1",
     "@vuepress/plugin-pwa": "^1.0.1",
-    "babel-eslint": "^10.0.1",
     "codecov": "^3.3.0",
     "cross-spawn": "^6.0.5",
-    "eslint": "^7.0.0",
-    "eslint4b": "^7.0.0",
+    "eslint": "^8.0.0-0",
+    "eslint4b": "^7.32.0",
     "fs-extra": "^8.0.1",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -6,8 +6,8 @@
 
 const fs = require("fs")
 const path = require("path")
-const { CLIEngine } = require("eslint")
-const linter = new CLIEngine({ fix: true })
+const { ESLint } = require("eslint")
+const linter = new ESLint({ fix: true })
 
 /**
  * Format a given text.
@@ -15,7 +15,7 @@ const linter = new CLIEngine({ fix: true })
  * @returns {string} The formatted text.
  */
 function format(text) {
-    const lintResult = linter.executeOnText(text)
+    const lintResult = linter.lintText(text)
     return lintResult.results[0].output || text
 }
 

--- a/tests/lib/illegal-eslint-disable-line.js
+++ b/tests/lib/illegal-eslint-disable-line.js
@@ -9,7 +9,6 @@ const path = require("path")
 const spawn = require("cross-spawn")
 const rimraf = require("rimraf")
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
 
 /**
  * Run eslint CLI command with a given source code.
@@ -84,7 +83,7 @@ no-undef*/
         ]) {
             it(code, () =>
                 runESLint(code).then(messages => {
-                    if (semver.satisfies(eslintVersion, ">=5.0.0")) {
+                    if (semver.satisfies(ESLint.version, ">=5.0.0")) {
                         assert.strictEqual(messages.length > 0, true)
                     }
                     const normalMessages = messages.filter(

--- a/tests/lib/rules/disable-enable-pair.js
+++ b/tests/lib/rules/disable-enable-pair.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { ESLint, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/disable-enable-pair")
 const tester = new RuleTester()
 
@@ -81,7 +80,7 @@ var foo = 1
             options: [{ allowWholeFile: true }],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   `
 /*eslint-disable no-undef -- description*/
@@ -211,7 +210,7 @@ console.log();
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-aggregating-enable.js
+++ b/tests/lib/rules/no-aggregating-enable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { ESLint, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-aggregating-enable")
 const tester = new RuleTester()
 
@@ -67,7 +66,7 @@ tester.run("no-aggregating-enable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-duplicate-disable.js
+++ b/tests/lib/rules/no-duplicate-disable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { ESLInt, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-duplicate-disable")
 const tester = new RuleTester()
 
@@ -123,7 +122,7 @@ tester.run("no-duplicate-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLInt.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: `

--- a/tests/lib/rules/no-restricted-disable.js
+++ b/tests/lib/rules/no-restricted-disable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const { Linter, RuleTester } = require("eslint")
+const { ESLint, Linter, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-restricted-disable")
 const coreRules = new Linter().getRules()
 const tester = new RuleTester()
@@ -157,7 +156,7 @@ tester.run("no-restricted-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: "/*eslint-disable -- description*/",

--- a/tests/lib/rules/no-unlimited-disable.js
+++ b/tests/lib/rules/no-unlimited-disable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unlimited-disable")
 const tester = new RuleTester()
 
@@ -95,7 +94,7 @@ tester.run("no-unlimited-disable", rule, {
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: "/*eslint-disable -- description */",

--- a/tests/lib/rules/no-unused-disable.js
+++ b/tests/lib/rules/no-unused-disable.js
@@ -20,7 +20,7 @@ const path = require("path")
 const spawn = require("cross-spawn")
 const rimraf = require("rimraf")
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
+const { ESLint } = require("eslint")
 
 /**
  * Run eslint CLI command with a given source code.
@@ -161,7 +161,7 @@ var foo = 3  /*eslint-disable-line no-shadow*/
 }
 `,
             // -- description
-            ...(semver.satisfies(eslintVersion, ">=7.0.0")
+            ...(semver.satisfies(ESLint.version, ">=7.0.0")
                 ? [
                       `/*eslint no-undef:error*/
 var a = b //eslint-disable-line -- description`,
@@ -827,7 +827,7 @@ var a = b /*eslint-disable-line no-undef*/`,
                 reportUnusedDisableDirectives: true,
             },
             // -- description
-            ...(semver.satisfies(eslintVersion, ">=7.0.0")
+            ...(semver.satisfies(ESLint.version, ">=7.0.0")
                 ? [
                       {
                           code: `/*eslint no-undef:off*/

--- a/tests/lib/rules/no-unused-enable.js
+++ b/tests/lib/rules/no-unused-enable.js
@@ -5,8 +5,7 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { ESLint, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-unused-enable")
 const tester = new RuleTester()
 
@@ -87,7 +86,7 @@ var a = b
             ],
         },
         // -- description
-        ...(semver.satisfies(eslintVersion, ">=7.0.0 || <6.0.0")
+        ...(semver.satisfies(ESLint.version, ">=7.0.0 || <6.0.0")
             ? [
                   {
                       code: "/*eslint-enable -- description*/",

--- a/tests/lib/rules/no-use.js
+++ b/tests/lib/rules/no-use.js
@@ -4,7 +4,7 @@
  */
 "use strict"
 
-const RuleTester = require("eslint").RuleTester
+const { RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/no-use")
 const tester = new RuleTester()
 

--- a/tests/lib/rules/require-description.js
+++ b/tests/lib/rules/require-description.js
@@ -5,12 +5,11 @@
 "use strict"
 
 const semver = require("semver")
-const eslintVersion = require("eslint/package").version
-const RuleTester = require("eslint").RuleTester
+const { ESLint, RuleTester } = require("eslint")
 const rule = require("../../../lib/rules/require-description")
 const tester = new RuleTester()
 
-if (!semver.satisfies(eslintVersion, ">=7.0.0")) {
+if (!semver.satisfies(ESLint.version, ">=7.0.0")) {
     // This rule can only be used with ESLint v7.x or later.
     return
 }


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [ ] [`@mysticatea/eslint-plugin`](https://github.com/mysticatea/eslint-plugin) (https://github.com/mysticatea/eslint-plugin/issues/31)
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/29
  - [ ] https://github.com/mysticatea/eslint-plugin/pull/32
  - [ ] Release
- [ ] [`eslint4b`](https://github.com/mysticatea/eslint4b) (https://github.com/mysticatea/eslint4b/issues/13)
  - [ ] https://github.com/mysticatea/eslint4b/pull/14
  - [ ] Release

---

Closes #62