### PR TITLE
Use syntax highlighting in code fences that Prism supports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ For example,
 
 Use [npm](https://www.npmjs.com/) or a compatible tool.
 
-```console
+```shell
 npm install --save-dev eslint eslint-plugin-eslint-comments
 ```
 
@@ -37,7 +37,7 @@ Configure your `.eslintrc.*` file.
 
 For example:
 
-```jsonc
+```json5
 {
     "extends": [
         "eslint:recommended",


### PR DESCRIPTION
This way these code blocks will syntax highlight in the VuePress docs because PrismJS supports them.